### PR TITLE
Fix CSV injection, release 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+
+## Version 1.1.4
+
+## Security
+- Precede cell values starting with = or another spreadsheet meta-character with a single quote to avoid CSV injection of formulas within a user's display name, category names, and tag names
+
+
 ## Version 1.1.3
 
 ### Changed

--- a/assets/functions.js
+++ b/assets/functions.js
@@ -1,15 +1,36 @@
 function posts_and_users_stats_export_table_to_csv(table, filename) {
-    const tmpColDelim = String.fromCharCode(11), tmpRowDelim = String.fromCharCode(0), // Temporary delimiters unlikely to be typed by keyboard to avoid accidentally splitting the actual contents
-        colDelim = '","', rowDelim = '"\r\n"', // actual delimiters for CSV
+    // Temporary delimiters unlikely to be typed by keyboard to avoid accidentally splitting the actual contents
+    const tmpColDelim = String.fromCharCode(11),
+        tmpRowDelim = String.fromCharCode(0),
+        // actual delimiters for CSV
+        colDelim = '","',
+        rowDelim = '"\r\n"',
+        forbiddenStartCharacters = ['+', '-', '=', '@'],
         rows = table.find('tr'),
-        csv = '"' + rows.map(function (i, row) {
-            const $row = jQuery(row), $cols = $row.find('td,th');
-            return $cols.map(function (j, col) {
-                const $col = jQuery(col), text = $col.text();
-                return text.replace(/"/g, '""'); // escape double quotes
-            }).get().join(tmpColDelim);
-        }).get().join(tmpRowDelim).split(tmpRowDelim)
-            .join(rowDelim).split(tmpColDelim)
+        csv = '"' + rows
+            .map(function (i, row) {
+                const $row = jQuery(row),
+                    $cols = $row.find('td,th');
+                return $cols
+                    .map(function (j, col) {
+                        const $col = jQuery(col);
+                        let text = $col.text();
+                        // Escape double quotes and trim result.
+                        text = text.replace(/"/g, '""').trim();
+                        // Prevent CSV injection.
+                        let startCharacter = text.substring(0, 1);
+                        if (forbiddenStartCharacters.includes(startCharacter)) {
+                            text = "'" + text;
+                        }
+                        return text;
+                    })
+                    .get()
+                    .join(tmpColDelim);
+            }).get()
+            .join(tmpRowDelim)
+            .split(tmpRowDelim)
+            .join(rowDelim)
+            .split(tmpColDelim)
             .join(colDelim) + '"',
         csvData = 'data:application/csv;charset=utf-8,' + encodeURIComponent(csv);
     jQuery(this).attr({

--- a/posts-and-users-stats.php
+++ b/posts-and-users-stats.php
@@ -3,7 +3,7 @@
  * Plugin Name: Posts and Users Stats
  * Plugin URI: https://patrick-robrecht.de/wordpress/
  * Description: Statistics about the number of posts and users, provided as diagrams, tables and csv export.
- * Version: 1.1.3
+ * Version: 1.1.4
  * Author: Patrick Robrecht
  * Author URI: https://patrick-robrecht.de/
  * License: GPLv3
@@ -16,7 +16,7 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-define( 'POSTS_AND_USERS_STATS_VERSION', '1.1.3' );
+define( 'POSTS_AND_USERS_STATS_VERSION', '1.1.4' );
 
 /**
  * Load text domain for translation.

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: patrickrobrecht
 Tags: dashboard, statistics
 Requires at least: 4.4
-Tested up to: 6.1
+Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 1.1.3
+Stable tag: 1.1.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -48,6 +48,9 @@ After the installation you can find the statistics as subpages of *Tools*.
 == Changelog ==
 
 If interested, please check up the [changelog at GitHub](https://github.com/patrickrobrecht/posts-and-users-stats#changelog).
+
+= 1.1.4 =
+* Security fix: Precede cell values starting with = or another spreadsheet meta-character with a single quote to avoid CSV injection of formulas within a user's display name, category names, and tag names
 
 = 1.1.3 =
 * Enhancement: Compliance with latest WP coding guidelines and other code style improvements


### PR DESCRIPTION
Fix https://github.com/patrickrobrecht/posts-and-users-stats/security/advisories/GHSA-qp4h-rgcv-q27p to avoid formulas in CSV file which could be included due to compromised user, category or tag names.